### PR TITLE
fix(android): avoid MessageQueue crash when registering compass sensors

### DIFF
--- a/android/src/main/java/app/capgo/capacitor/compass/CapgoCompass.java
+++ b/android/src/main/java/app/capgo/capacitor/compass/CapgoCompass.java
@@ -7,7 +7,7 @@ import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.hardware.display.DisplayManager;
 import android.os.Handler;
-import android.os.HandlerThread;
+import android.os.Looper;
 import android.util.Log;
 import android.view.Display;
 import android.view.Surface;
@@ -37,8 +37,6 @@ public class CapgoCompass implements SensorEventListener {
     private AccuracyCallback accuracyCallback;
     private volatile int currentAccuracy = -1; // -1 = UNKNOWN
 
-    // Background thread for sensor processing
-    private HandlerThread sensorThread;
     private Handler sensorHandler;
 
     // Throttling state
@@ -93,33 +91,65 @@ public class CapgoCompass implements SensorEventListener {
         this.minHeadingChange = minHeadingChange > 0 ? minHeadingChange : DEFAULT_MIN_HEADING_CHANGE;
     }
 
-    public void registerListeners() {
-        // Create background thread for sensor processing
-        sensorThread = new HandlerThread("CompassSensorThread");
-        sensorThread.start();
-        sensorHandler = new Handler(sensorThread.getLooper());
+    /**
+     * Register sensor listeners on the main thread looper.
+     *
+     * @return true when listeners were registered, false when registration cannot proceed
+     */
+    public boolean registerListeners() {
+        if (sensorHandler != null) {
+            return true;
+        }
+
+        if (sensorManager == null) {
+            Log.e(TAG, "SensorManager is not available");
+            return false;
+        }
+
+        if (magnetometer == null && accelerometer == null) {
+            Log.e(TAG, "No compass sensors available on this device");
+            return false;
+        }
+
+        Looper mainLooper = Looper.getMainLooper();
+        if (mainLooper == null) {
+            Log.e(TAG, "Main looper is not available");
+            return false;
+        }
+
+        sensorHandler = new Handler(mainLooper);
 
         // Reset throttling state
         lastNotifyTime = 0;
         lastNotifiedHeading = -1;
 
-        if (this.magnetometer != null) {
-            this.sensorManager.registerListener(this, this.magnetometer, SensorManager.SENSOR_DELAY_NORMAL, sensorHandler);
-        }
-        if (this.accelerometer != null) {
-            this.sensorManager.registerListener(this, this.accelerometer, SensorManager.SENSOR_DELAY_NORMAL, sensorHandler);
+        try {
+            boolean registered = false;
+            if (magnetometer != null) {
+                registered = sensorManager.registerListener(this, magnetometer, SensorManager.SENSOR_DELAY_NORMAL, sensorHandler);
+            }
+            if (accelerometer != null) {
+                registered =
+                    sensorManager.registerListener(this, accelerometer, SensorManager.SENSOR_DELAY_NORMAL, sensorHandler) || registered;
+            }
+            if (!registered) {
+                unregisterListeners();
+                Log.e(TAG, "Failed to register sensor listeners");
+                return false;
+            }
+            return true;
+        } catch (RuntimeException e) {
+            unregisterListeners();
+            Log.e(TAG, "Failed to register sensor listeners", e);
+            return false;
         }
     }
 
     public void unregisterListeners() {
-        this.sensorManager.unregisterListener(this);
-
-        // Clean up background thread
-        if (sensorThread != null) {
-            sensorThread.quitSafely();
-            sensorThread = null;
-            sensorHandler = null;
+        if (sensorManager != null) {
+            sensorManager.unregisterListener(this);
         }
+        sensorHandler = null;
     }
 
     private DisplayRotation getDisplayRotation() {

--- a/android/src/main/java/app/capgo/capacitor/compass/CapgoCompassPlugin.java
+++ b/android/src/main/java/app/capgo/capacitor/compass/CapgoCompassPlugin.java
@@ -1,5 +1,6 @@
 package app.capgo.capacitor.compass;
 
+import android.util.Log;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -23,7 +24,9 @@ public class CapgoCompassPlugin extends Plugin {
     public void handleOnResume() {
         super.handleOnResume();
         if (this.implementation != null && isListening) {
-            this.implementation.registerListeners();
+            if (!this.implementation.registerListeners()) {
+                Log.e("CapgoCompassPlugin", "Failed to re-register compass sensor listeners on resume");
+            }
         }
     }
 
@@ -75,7 +78,12 @@ public class CapgoCompassPlugin extends Plugin {
             notifyListeners("headingChange", ret);
         });
 
-        implementation.registerListeners();
+        if (!implementation.registerListeners()) {
+            isListening = false;
+            implementation.setHeadingCallback(null);
+            call.reject("Failed to register compass sensor listeners");
+            return;
+        }
         call.resolve();
     }
 

--- a/example-app/index.html
+++ b/example-app/index.html
@@ -3,14 +3,13 @@
   <head>
     <meta charset="utf-8" />
 
-
     <meta
       name="viewport"
       content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
     <meta name="format-detection" content="telephone=no" />
     <meta name="msapplication-tap-highlight" content="no" />
-<title>@capgo/capacitor-compass</title>
+    <title>@capgo/capacitor-compass</title>
     <link rel="stylesheet" href="/src/style.css" />
   </head>
   <body>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Register compass sensor listeners on the main looper instead of a freshly started `HandlerThread`
- Return registration success from `CapgoCompass.registerListeners()`
- Reject `startListening` when sensor registration fails instead of crashing the process

Fixes #12

## Why
Play Console reports a crash when `startListening` calls `SensorManager.registerListener` with a `Handler` backed by a `HandlerThread` whose `MessageQueue` is not initialized yet on some devices:

```
Caused by java.lang.RuntimeException: MessageQueue is not initialized.
  at android.hardware.SystemSensorManager$BaseEventQueue.nativeInitBaseEventQueue
  at android.hardware.SensorManager.registerListener
  at app.capgo.capacitor.compass.CapgoCompass.registerListeners
  at app.capgo.capacitor.compass.CapgoCompassPlugin.startListening
```

## How
- Use `Looper.getMainLooper()` for sensor delivery, which is always initialized when the activity bridge is running
- Guard against missing `SensorManager`/sensors and catch `RuntimeException` during registration
- On failure, clean up partial registration and return `false`
- `startListening` resets listening state and rejects the plugin call with a clear error message

## Testing
- `bun run fmt`
- `bun run lint`
- `bun run verify:web`
- `bun run verify:android` (clean build + unit tests)

## Not Tested
- Manual device verification on the specific Play Console crash device/OS build
- iOS (`verify:ios` not run on Linux CI agent)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a48b1164-0a3e-4464-bab3-3cec02049289?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a48b1164-0a3e-4464-bab3-3cec02049289&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-compass/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789215400&installation_model_id=430928&pr_number=13&repository=Cap-go%2Fcapacitor-compass&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-compass%2Fpull%2F13&signature=ce1c9a071f50787d1e17e10c8579f8b5093e2b07d5e7ed9086f8479a24d6b214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-compass/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

